### PR TITLE
2.3.11からpecl側でunixodbc.hが見つからないエラーでビルドできないのでバージョンを下げる

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -7,11 +7,13 @@ RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev li
   && docker-php-ext-install mbstring dom gd zip pdo_mysql ldap\
   && apt-get clean
 
+# install pre sql server driver
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-  && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
+  && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list \
   && apt-get update \
-  && apt-get install -y unixodbc-dev libgssapi-krb5-2 \
-  && ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools
+  && apt-get install -y odbcinst1debian2=2.3.7 unixodbc=2.3.7 odbcinst=2.3.7 unixodbc-dev=2.3.7 \
+  && apt-get install -y libgssapi-krb5-2 \
+  && ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18
 
 # install sql server driver
 RUN pecl install sqlsrv && pecl install pdo_sqlsrv && docker-php-ext-enable sqlsrv && docker-php-ext-enable pdo_sqlsrv


### PR DESCRIPTION
下記のエラーのためビルドができない問題を修正
unixodbcの2.3.11ではunixodbc.hが含まれないためpeclのsqlsrv, pdo_sqlsrvがビルドできなかった。

```
% docker-compsoe build --no-cache
web uses an image, skipping
Building php
[+] Building 71.8s (11/14)
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                0.0s
 => => transferring dockerfile: 1.07kB                                                                                                                                                                                                                              0.0s 
 => [internal] load .dockerignore                                                                                                                                                                                                                                   0.0s 
 => => transferring context: 2B                                                                                                                                                                                                                                     0.0s 
 => [internal] load metadata for docker.io/library/php:8.0-fpm                                                                                                                                                                                                      1.0s 
 => CACHED [ 1/10] FROM docker.io/library/php:8.0-fpm@sha256:14322a1dc8596657219b1c51509c06e2573b848fcc5269e624093a340c7e87a7                                                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                                                                                                   0.1s 
 => => transferring context: 26B                                                                                                                                                                                                                                    0.0s 
 => [ 2/10] RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev libpng-dev libzip-dev libonig-dev default-mysql-client libldap2-dev  && docker-php-ext-install mbstring dom gd zip pdo_mysql ldap  && apt-get clean                      54.9s 
 => [ 3/10] RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -   && curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list > /etc/apt/sources.list.d/mssql-release.list   && apt-get update                                      2.2s
 => [ 4/10] RUN apt-get install -y unixodbc-dev                                                                                                                                                                                                                     3.1s
 => [ 5/10] RUN apt-get install -y libgssapi-krb5-2                                                                                                                                                                                                                 1.0s
 => [ 6/10] RUN ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18                                                                                                                                                                                          2.4s
 => ERROR [ 7/10] RUN pecl install sqlsrv-5.9.0 && pecl install pdo_sqlsrv-5.9.0 && docker-php-ext-enable sqlsrv && docker-php-ext-enable pdo_sqlsrv                                                                                                                6.9s
------
 > [ 7/10] RUN pecl install sqlsrv-5.9.0 && pecl install pdo_sqlsrv-5.9.0 && docker-php-ext-enable sqlsrv && docker-php-ext-enable pdo_sqlsrv:
#10 4.384 downloading sqlsrv-5.9.0.tgz ...
#10 4.384 Starting to download sqlsrv-5.9.0.tgz (189,701 bytes)
#10 4.385 .........................................done: 189,701 bytes
#10 5.064 34 source files, building
#10 5.064 running: phpize
#10 5.068 Configuring for:
#10 5.068 PHP Api Version:         20200930
#10 5.068 Zend Module Api No:      20200930
#10 5.068 Zend Extension Api No:   420200930
#10 5.412 building in /tmp/pear/temp/pear-build-defaultuserGPoOiK/sqlsrv-5.9.0
#10 5.412 running: /tmp/pear/temp/sqlsrv/configure --with-php-config=/usr/local/bin/php-config
#10 5.467 checking for grep that handles long lines and -e... /bin/grep
#10 5.468 checking for egrep... /bin/grep -E
#10 5.471 checking for a sed that does not truncate output... /bin/sed
#10 5.476 checking for pkg-config... /usr/bin/pkg-config
#10 5.477 checking pkg-config is at least version 0.9.0... yes
#10 5.477 checking for cc... cc
#10 5.510 checking whether the C compiler works... yes
#10 5.510 checking for C compiler default output file name... a.out
#10 5.530 checking for suffix of executables...
#10 5.553 checking whether we are cross compiling... no
#10 5.565 checking for suffix of object files... o
#10 5.577 checking whether we are using the GNU C compiler... yes
#10 5.588 checking whether cc accepts -g... yes
#10 5.606 checking for cc option to accept ISO C89... none needed
#10 5.619 checking how to run the C preprocessor... cc -E
#10 5.637 checking for icc... no
#10 5.641 checking for suncc... no
#10 5.642 checking for system library directory... lib
#10 5.663 checking if compiler supports -Wl,-rpath,... yes
#10 5.692 checking build system type... x86_64-pc-linux-gnu
#10 5.692 checking host system type... x86_64-pc-linux-gnu
#10 5.692 checking target system type... x86_64-pc-linux-gnu
#10 5.713 checking for PHP prefix... /usr/local
#10 5.713 checking for PHP includes... -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
#10 5.713 checking for PHP extension directory... /usr/local/lib/php/extensions/no-debug-non-zts-20200930
#10 5.713 checking for PHP installed headers prefix... /usr/local/include/php
#10 5.723 checking if debug is enabled... no
#10 5.731 checking if zts is enabled... no
#10 5.731 checking for gawk... no
#10 5.732 checking for nawk... nawk
#10 5.732 checking if nawk is broken... no
#10 5.733 checking whether to enable sqlsrv functions... yes, shared
#10 5.733 checking for SQLSRV headers... /tmp/pear/temp/sqlsrv/shared/
#10 5.737 checking for g++... g++
#10 5.760 checking whether we are using the GNU C++ compiler... yes
#10 5.772 checking whether g++ accepts -g... yes
#10 5.788 checking how to run the C++ preprocessor... g++ -E
#10 5.826 checking for a sed that does not truncate output... /bin/sed
#10 5.828 checking for ld used by cc... /usr/bin/ld
#10 5.830 checking if the linker (/usr/bin/ld) is GNU ld... yes
#10 5.830 checking for /usr/bin/ld option to reload object files... -r
#10 5.832 checking for BSD-compatible nm... /usr/bin/nm -B
#10 5.832 checking whether ln -s works... yes
#10 5.832 checking how to recognize dependent libraries... pass_all
#10 5.905 checking for ANSI C header files... yes
#10 5.920 checking for sys/types.h... yes
#10 5.938 checking for sys/stat.h... yes
#10 5.955 checking for stdlib.h... yes
#10 5.973 checking for string.h... yes
#10 5.991 checking for memory.h... yes
#10 6.013 checking for strings.h... yes
#10 6.032 checking for inttypes.h... yes
#10 6.050 checking for stdint.h... yes
#10 6.069 checking for unistd.h... yes
#10 6.087 checking dlfcn.h usability... yes
#10 6.093 checking dlfcn.h presence... yes
#10 6.093 checking for dlfcn.h... yes
#10 6.096 checking how to run the C++ preprocessor... g++ -E
#10 6.113 checking the maximum length of command line arguments... 1572864
#10 6.158 checking command to parse /usr/bin/nm -B output from cc object... ok
#10 6.160 checking for objdir... .libs
#10 6.161 checking for ar... ar
#10 6.161 checking for ranlib... ranlib
#10 6.161 checking for strip... strip
#10 6.210 checking if cc supports -fno-rtti -fno-exceptions... no
#10 6.210 checking for cc option to produce PIC... -fPIC
#10 6.222 checking if cc PIC flag -fPIC works... yes
#10 6.266 checking if cc static flag -static works... yes
#10 6.282 checking if cc supports -c -o file.o... yes
#10 6.290 checking whether the cc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
#10 6.305 checking whether -lc should be explicitly linked in... no
#10 6.314 checking dynamic linker characteristics... GNU/Linux ld.so
#10 6.314 checking how to hardcode library paths into programs... immediate
#10 6.315 checking whether stripping libraries is possible... yes
#10 6.316 checking if libtool supports shared libraries... yes
#10 6.316 checking whether to build shared libraries... yes
#10 6.316 checking whether to build static libraries... no
#10 6.398
#10 6.398 creating libtool
#10 6.410 appending configuration tag "CXX" to libtool
#10 6.458 checking for ld used by g++... /usr/bin/ld -m elf_x86_64
#10 6.460 checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
#10 6.464 checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
#10 6.492 checking for g++ option to produce PIC... -fPIC
#10 6.503 checking if g++ PIC flag -fPIC works... yes
#10 6.548 checking if g++ static flag -static works... yes
#10 6.563 checking if g++ supports -c -o file.o... yes
#10 6.563 checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
#10 6.566 checking dynamic linker characteristics... GNU/Linux ld.so
#10 6.566 (cached) (cached) checking how to hardcode library paths into programs... immediate
#10 6.692 configure: patching config.h.in
#10 6.694 configure: creating ./config.status
#10 6.722 config.status: creating config.h
#10 6.745 running: make
#10 6.747 /bin/bash /tmp/pear/temp/pear-build-defaultuserGPoOiK/sqlsrv-5.9.0/libtool --mode=compile g++ -I. -I/tmp/pear/temp/sqlsrv -I/tmp/pear/temp/pear-build-defaultuserGPoOiK/sqlsrv-5.9.0/include -I/tmp/pear/temp/pear-build-defaultuserGPoOiK/sqlsrv-5.9.0/main -I
/tmp/pear/temp/sqlsrv -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib -I/tmp/pear/temp/sqlsrv/shared/  -DHAVE_CONFIG_H  -std=c++11 -D_FORTIFY_SOURCE=2 -O2 -fstack-protector   -std=c++11 -c /tmp/pear/temp/sqlsrv/conn.cpp -o conn.lo
#10 6.794 mkdir .libs
#10 6.796  g++ -I. -I/tmp/pear/temp/sqlsrv -I/tmp/pear/temp/pear-build-defaultuserGPoOiK/sqlsrv-5.9.0/include -I/tmp/pear/temp/pear-build-defaultuserGPoOiK/sqlsrv-5.9.0/main -I/tmp/pear/temp/sqlsrv -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local
/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib -I/tmp/pear/temp/sqlsrv/shared/ -DHAVE_CONFIG_H -std=c++11 -D_FORTIFY_SOURCE=2 -O2 -fstack-protector -std=c++11 -c /tmp/pear/temp/sqlsrv/conn.cpp  -fPIC -DPIC -o .libs/conn.o
#10 6.864 In file included from /usr/include/sql.h:19,
#10 6.864                  from /tmp/pear/temp/sqlsrv/shared/xplat.h:30,
#10 6.864                  from /tmp/pear/temp/sqlsrv/shared/typedefs_for_linux.h:23,
#10 6.864                  from /tmp/pear/temp/sqlsrv/shared/xplat_winnls.h:24,
#10 6.864                  from /tmp/pear/temp/sqlsrv/shared/FormattedPrint.h:24,
#10 6.864                  from /tmp/pear/temp/sqlsrv/shared/core_sqlsrv.h:41,
#10 6.864                  from /tmp/pear/temp/sqlsrv/php_sqlsrv_int.h:25,
#10 6.864                  from /tmp/pear/temp/sqlsrv/conn.cpp:24:
#10 6.864 /usr/include/sqltypes.h:56:10: fatal error: unixodbc.h: No such file or directory
#10 6.864    56 | #include "unixodbc.h"
#10 6.864       |          ^~~~~~~~~~~~
#10 6.864 compilation terminated.
#10 6.866 make: *** [Makefile:209: conn.lo] Error 1
#10 6.867 ERROR: `make' failed

```